### PR TITLE
fix: resolveImportedPackage does not include test files of *_test pac…

### DIFF
--- a/resolve.go
+++ b/resolve.go
@@ -116,6 +116,7 @@ func resolveImportedPackage(pkg *build.Package, err error) ([]string, error) {
 	files = append(files, pkg.GoFiles...)
 	files = append(files, pkg.CgoFiles...)
 	files = append(files, pkg.TestGoFiles...)
+	files = append(files, pkg.XTestGoFiles...)
 	if pkg.Dir != "." {
 		for i, f := range files {
 			files[i] = filepath.Join(pkg.Dir, f)


### PR DESCRIPTION
`dots` does not retrieve all the files yield by go/build. More specifically it doesn't include files under packages `*_test`
Context: see mgechev/revive#1357

This PR fix the problem by including `build.Package.XTestGoFiles` (_`_test.go` files outside package_) in the final result.