### PR TITLE
chore: revert Go version to 1.23.0 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/mgechev/dots
 
-go 1.23.1
+go 1.23.0


### PR DESCRIPTION
Change Go version in go.mod to be the same as in [the revive's.](https://github.com/mgechev/revive/blob/e16f5aa5a679cfa68c3405651f617378aeed3337/go.mod#L3)