### PR TITLE
test: add missing test cases for Resolve

### DIFF
--- a/fixtures/withtests/gofile.go
+++ b/fixtures/withtests/gofile.go
@@ -1,0 +1,1 @@
+package bar

--- a/fixtures/withtests/testgo_test.go
+++ b/fixtures/withtests/testgo_test.go
@@ -1,0 +1,1 @@
+package bar_test

--- a/fixtures/withtests/xtestgo_test.go
+++ b/fixtures/withtests/xtestgo_test.go
@@ -1,0 +1,1 @@
+package bar

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -1,6 +1,7 @@
 package dots
 
 import (
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -29,6 +30,32 @@ func TestResolve(t *testing.T) {
 		"fixtures/dummy/baz/baz1.go",
 		"fixtures/dummy/baz/baz2.go",
 		"fixtures/dummy/baz/baz3.go",
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result) != len(files) {
+		t.Fatalf("Matched different number of files: got=%v, want=%v", len(result), len(files))
+	}
+	for _, r := range result {
+		matched := false
+		for _, e := range files {
+			matched = matched || strings.HasSuffix(r, e)
+		}
+		if !matched {
+			t.Errorf("Not supposed to match: %v", r)
+		}
+	}
+}
+
+func TestResolveTests(t *testing.T) {
+	result, err := Resolve([]string{"fixtures/withtests/..."}, []string{})
+
+	files := []string{
+		filepath.FromSlash("fixtures/withtests/gofile.go"),
+		filepath.FromSlash("fixtures/withtests/testgo_test.go"),
+		filepath.FromSlash("fixtures/withtests/xtestgo_test.go"),
 	}
 
 	if err != nil {

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -2,7 +2,6 @@ package dots
 
 import (
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -18,18 +17,14 @@ func TestResolveNoArgs(t *testing.T) {
 }
 
 func TestResolve(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.SkipNow()
-	}
-
 	result, err := Resolve([]string{"fixtures/dummy/..."}, []string{"fixtures/dummy/foo", "fixtures/dummy/UNKNOWN"})
 
 	files := []string{
-		"fixtures/dummy/bar/bar1.go",
-		"fixtures/dummy/bar/bar2.go",
-		"fixtures/dummy/baz/baz1.go",
-		"fixtures/dummy/baz/baz2.go",
-		"fixtures/dummy/baz/baz3.go",
+		filepath.FromSlash("fixtures/dummy/bar/bar1.go"),
+		filepath.FromSlash("fixtures/dummy/bar/bar2.go"),
+		filepath.FromSlash("fixtures/dummy/baz/baz1.go"),
+		filepath.FromSlash("fixtures/dummy/baz/baz2.go"),
+		filepath.FromSlash("fixtures/dummy/baz/baz3.go"),
 	}
 
 	if err != nil {


### PR DESCRIPTION
This PR adds test cases to cover the problem fixed in #5.

Enables previously skipped tests on Windows.